### PR TITLE
Fix install button in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ An directory for icons, tile images, and screenshots.
 
 - <a href="https://www.cloudflare.com/apps/developer/docs/getting-started">The Cloudflare developer documentation</a> for examples and API usage.
 
-<a href="https://www.cloudflare.com/apps/[[YOUR APP ALIAS]]/install?source=button">
+<a href="https://www.cloudflare.com/apps/ZCDIXCYkgZ6P/install?source=button">
   <img
     src="https://install.cloudflareapps.com/install-button.png"
-    alt="Install [[YOUR APP NAME]] with Cloudflare"
+    alt="Install Welcome Bar with Cloudflare"
     border="0"
     width="150">
 </a>


### PR DESCRIPTION
Replace placeholder for app ID in install link on button, fixing the 404, and replace placeholder in alt text of the button image.